### PR TITLE
(maint) Add 'fileutils' library to secret_createkeys task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Release 0.1.1
+
+### Bug fixes
+
+* **Add missing `fileutils` library in `secret_createkeys` task**
+
+  The `fileutils` library was not included in the `secret_createkeys` task, causing the
+  task to error on some platforms.
+
 ## Release 0.1.0
 
 This is the initial release.

--- a/tasks/secret_createkeys.rb
+++ b/tasks/secret_createkeys.rb
@@ -3,6 +3,7 @@
 
 require 'openssl'
 require 'base64'
+require 'fileutils'
 
 require_relative "../../ruby_task_helper/files/task_helper.rb"
 


### PR DESCRIPTION
The `fileutils` library was not required in the `secret_createkeys`
task, causing the task to error on some platforms.