### PR TITLE
Fix typo in secret_decrypt description

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   TargetRubyVersion: 2.5
   Exclude:
     - 'Boltdir/**/*'
@@ -8,6 +9,7 @@ AllCops:
     - 'modules/**/*'
     - 'docs/**/*'
     - 'site-modules/**/*'
+    - 'Gemfile'
 
 # Checks for if and unless statements that would fit on one line if written as a
 # modifier if/unless.
@@ -39,6 +41,12 @@ Style/NumericLiterals:
   Enabled: false
 
 Style/NumericPredicate:
+  Enabled: false
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
   Enabled: false
 
 Style/StderrPuts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Release 0.1.2
+
+### Bug fixes
+
+* **Update secret_decrypt plugin description from 'encrypt' to 'decrypt'**
+  
+  Fixes a typo in the secret_decrypt plugin description.
+
 ## Release 0.1.1
 
 ### Bug fixes

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
   
 {
   "name": "puppetlabs-pkcs7",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "puppetlabs",
   "summary": "Bolt plugin to encrypt and decrypt sensitive data",
   "license": "Apache-2.0",

--- a/tasks/secret_decrypt.json
+++ b/tasks/secret_decrypt.json
@@ -1,5 +1,5 @@
 {
-  "description": "Encrypt sensitive data with pkcs7",
+  "description": "Decrypt sensitive data with pkcs7",
   "input_method": "stdin",
   "parameters": {
     "encrypted_value": {

--- a/tasks/secret_encrypt.rb
+++ b/tasks/secret_encrypt.rb
@@ -14,7 +14,7 @@ class PKCS7Encrypt < TaskHelper
     debug("Using public key: #{public_key_path}")
 
     # Initialize the cipher
-    cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+    cipher = OpenSSL::Cipher.new('aes-256-cbc')
 
     # Encrypt plaintext
     raw = OpenSSL::PKCS7.encrypt([public_key], opts[:plaintext_value], cipher, OpenSSL::PKCS7::BINARY).to_der


### PR DESCRIPTION
Update the secrete_decrypt task description to accurately say 'Decrypt'
instead of 'encrypt'