### PR TITLE
Add PDK gem dependency for release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 0.1.3
+
+### Bug fixes
+
+* **Add PDK gem dependency for release**
+
 ## Release 0.1.2
 
 ### Bug fixes

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,8 @@ minor_version = ruby_version_segments[0..1].join('.')
 group :development do
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
+  gem 'pdk', *location_for(ENV['PDK_GEM_VERSION'])
   gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
   # Pin puppet blacksmith to avoid failures in forge module push job
-  gem "puppet-blacksmith", "4.1.2"
+  gem 'puppet-blacksmith', '4.1.2'
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
   
 {
   "name": "puppetlabs-pkcs7",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "puppetlabs",
   "summary": "Bolt plugin to encrypt and decrypt sensitive data",
   "license": "Apache-2.0",


### PR DESCRIPTION
Back in September we added PDK as a dependency for the release process
to [all](https://github.com/puppetlabs/puppetlabs-terraform/pull/24)
[of](https://github.com/puppetlabs/puppetlabs-vault/pull/14)
[our](https://github.com/puppetlabs/puppetlabs-aws_inventory/pull/12)
[modules](https://github.com/puppetlabs/puppetlabs-azure_inventory/pull/11)
except apparently this one.

Also adds updates for re-tag and release.